### PR TITLE
Implement emailJobs GraphQL query

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import pkg from "../package.json";
 import i18n from "./i18n/index.js";
 import mutations from "./mutations/index.js";
 import policies from "./policies.json";
+import queries from "./queries/index.js";
 import startup from "./startup.js";
 import resolvers from "./resolvers/index.js";
 import schemas from "./schemas/index.js";
@@ -32,6 +33,7 @@ export default async function register(app) {
     },
     mutations,
     policies,
+    queries,
     functionsByType: {
       startup: [startup]
     }

--- a/src/queries/emailJobs.js
+++ b/src/queries/emailJobs.js
@@ -4,7 +4,7 @@
  * @memberof Email
  * @summary query the Jobs collection and return email jobs
  * @param {Object} context - an object containing the per-request state
- * @param {String} shopIds - ids of the shops to get emails for
+ * @param {String[]} shopIds - ids of the shops to get emails for
  * @returns {Object} group object
  */
 export default async function emailJobs(context, shopIds) {

--- a/src/queries/emailJobs.js
+++ b/src/queries/emailJobs.js
@@ -16,7 +16,7 @@ export default async function emailJobs(context, shopIds) {
   await Promise.all(validatePermissionsForShopIds);
 
   return Jobs.find({
-    type: "sendEmail",
+    "type": "sendEmail",
     "data.shopId": {
       $in: shopIds
     }

--- a/src/queries/emailJobs.js
+++ b/src/queries/emailJobs.js
@@ -1,0 +1,24 @@
+/**
+ * @name emailJobs
+ * @method
+ * @memberof Email
+ * @summary query the Jobs collection and return email jobs
+ * @param {Object} context - an object containing the per-request state
+ * @param {String} shopIds - ids of the shops to get emails for
+ * @returns {Object} group object
+ */
+export default async function emailJobs(context, shopIds) {
+  const { collections } = context;
+  const { Jobs } = collections;
+
+  const validatePermissionsForShopIds = shopIds.map((shopId) => context.validatePermissions("reaction:legacy:emails", "read", { shopId }));
+
+  await Promise.all(validatePermissionsForShopIds);
+
+  return Jobs.find({
+    type: "sendEmail",
+    "data.shopId": {
+      $in: shopIds
+    }
+  });
+}

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -1,0 +1,5 @@
+import emailJobs from "./emailJobs.js";
+
+export default {
+  emailJobs
+};

--- a/src/resolvers/Query/emailJobs.js
+++ b/src/resolvers/Query/emailJobs.js
@@ -1,0 +1,32 @@
+import getPaginatedResponse from "@reactioncommerce/api-utils/graphql/getPaginatedResponse.js";
+import wasFieldRequested from "@reactioncommerce/api-utils/graphql/wasFieldRequested.js";
+import { decodeShopOpaqueId } from "../../xforms/id.js";
+
+/**
+ * @name Query.emailJobs
+ * @method
+ * @memberof Routes/GraphQL
+ * @summary Returns a paginated list of `sendEmail` jobs
+ * @param {Object} parentResult unused
+ * @param {Object} args Arguments from the client
+ * @param {String} args.shopIds IDs of the shops to get emails for
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} info Info about the GraphQL request
+ * @returns {Promise<Object>} Email jobs connection
+ */
+export default async function emailJobs(parentResult, args, context, info) {
+  const {
+    shopIds: opaqueShopIds,
+    ...connectionArgs
+  } = args;
+
+  const shopIds = opaqueShopIds.map((opaqueShopId) => decodeShopOpaqueId(opaqueShopId));
+
+  const cursor = await context.queries.emailJobs(context, shopIds);
+
+  return getPaginatedResponse(cursor, connectionArgs, {
+    includeHasNextPage: wasFieldRequested("pageInfo.hasNextPage", info),
+    includeHasPreviousPage: wasFieldRequested("pageInfo.hasPreviousPage", info),
+    includeTotalCount: wasFieldRequested("totalCount", info)
+  });
+}

--- a/src/resolvers/Query/index.js
+++ b/src/resolvers/Query/index.js
@@ -1,0 +1,5 @@
+import emailJobs from "./emailJobs.js";
+
+export default {
+  emailJobs
+};

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -1,5 +1,7 @@
 import Mutation from "./Mutation/index.js";
+import Query from "./Query/index.js";
 
 export default {
-  Mutation
+  Mutation,
+  Query
 };

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -1,7 +1,9 @@
+import getConnectionTypeResolvers from "@reactioncommerce/api-utils/graphql/getConnectionTypeResolvers.js";
 import Mutation from "./Mutation/index.js";
 import Query from "./Query/index.js";
 
 export default {
   Mutation,
-  Query
+  Query,
+  ...getConnectionTypeResolvers("EmailJob")
 };

--- a/src/schemas/emailJobs.graphql
+++ b/src/schemas/emailJobs.graphql
@@ -1,0 +1,77 @@
+"The data of the e-mail"
+type EmailJobData {
+    "The address the e-mail was/is being/will be sent to"
+    to: String!
+
+    "The subject of the e-mail"
+    subject: String!
+}
+
+"An e-mail job"
+type EmailJob {
+    "The date and time of the last update to the e-mail job"
+    updated: DateTime!
+
+    "The status of the e-mail job"
+    status: String!
+
+    "The data of the e-mail"
+    data: EmailJobData!
+}
+
+"A connection edge in which each node is an `EmailJob` object"
+type EmailJobEdge {
+    "The cursor that represents this node in the paginated results"
+    cursor: ConnectionCursor!
+
+    "The product"
+    node: EmailJob
+}
+
+"""
+Wraps a list of `EmailJob`s, providing pagination cursors and information.
+
+For information about what Relay-compatible connections are and how to use them, see the following articles:
+- [Relay Connection Documentation](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections)
+- [Relay Connection Specification](https://facebook.github.io/relay/graphql/connections.htm)
+- [Using Relay-style Connections With Apollo Client](https://www.apollographql.com/docs/react/recipes/pagination.html)
+"""
+type EmailJobConnection {
+    "The list of nodes that match the query, wrapped in an edge to provide a cursor string for each"
+    edges: [EmailJobEdge]
+
+    """
+    You can request the `nodes` directly to avoid the extra wrapping that `NodeEdge` has,
+    if you know you will not need to paginate the results.
+    """
+    nodes: [EmailJob]
+
+    "Information to help a client request the next or previous page"
+    pageInfo: PageInfo!
+
+    "The total number of nodes that match your query"
+    totalCount: Int!
+}
+
+extend type Query {
+    "Get e-mail jobs for a given set of shops"
+    emailJobs(
+        "The shop IDs to get e-mail jobs for"
+        shopIds: [ID]!,
+
+        "Return only results that come after this cursor. Use this with `first` to specify the number of results to return."
+        after: ConnectionCursor,
+
+        "Return only results that come before this cursor. Use this with `last` to specify the number of results to return."
+        before: ConnectionCursor,
+
+        "Return at most this many results. This parameter may be used with either `after` or `offset` parameters."
+        first: ConnectionLimitInt,
+
+        "Return at most this many results. This parameter may be used with the `before` parameter."
+        last: ConnectionLimitInt,
+
+        "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+        offset: Int
+    ): EmailJobConnection!
+}

--- a/src/schemas/emailJobs.graphql
+++ b/src/schemas/emailJobs.graphql
@@ -9,6 +9,9 @@ type EmailJobData {
 
 "An e-mail job"
 type EmailJob {
+    "The ID of the e-mail job"
+    _id: ID!
+
     "The date and time of the last update to the e-mail job"
     updated: DateTime!
 

--- a/src/schemas/index.js
+++ b/src/schemas/index.js
@@ -1,5 +1,6 @@
 import importAsString from "@reactioncommerce/api-utils/importAsString.js";
 
+const emailJobs = importAsString("./emailJobs.graphql");
 const retryFailedEmail = importAsString("./retryFailedEmail.graphql");
 
-export default [retryFailedEmail];
+export default [emailJobs, retryFailedEmail];


### PR DESCRIPTION
Resolves https://github.com/reactioncommerce/reaction-admin/issues/325
Impact: **major**
Type: **feature**

## Issue
There is currently no way to retried email jobs through GraphQL.

## Solution
Implement an `emailJobs` GraphQL query with pagination.

## Breaking changes
None.

## Testing
1. In the playground, query `emailJobs`.
2. You should get your email jobs.
